### PR TITLE
Earn/db multi server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ jspm_packages/
 
 # dotenv environment variables file
 .env
+.env.development
 
 # next.js build output
 .next

--- a/db.js
+++ b/db.js
@@ -27,14 +27,15 @@ class PointGivenBy {
 
 // eslint-disable-next-line no-shadow
 const createDbProps = (db) => {
-	const props = ["points", "example"];
-	for (const prop of props) {
-		const isInDB = prop in db.data;
-		if (!isInDB) {
-			db.data[prop] = {};
-		}
-	}
-	console.log("added necessary props to db.json");
+	const serverProps = ["867244851098288149", "939629912623575090"];
+	const featureProps = ["points", "example"];
+	serverProps.forEach((prop) => {
+		db.data[prop] = {};
+		featureProps.forEach((fprop) => {
+			db.data[prop][fprop] = {};
+		});
+	});
+	console.log("added necessary server and feature props to db.json");
 };
 
 const checkDB = (path = "db.json") => {
@@ -63,14 +64,13 @@ const checkDB = (path = "db.json") => {
 checkDB();
 
 
-
 const db = new LowSync(new JSONFileSync("db.json"));
 db.read();
 
 
-export const addUserToPoints = (userId) => {
+export const addUserToPoints = (userId, guildId) => {
 	// eslint-disable-next-line no-prototype-builtins
-	const { points } = db.data;
+	const { points } = db.data[guildId];
 	if (points.hasOwnProperty(userId)) return;
 
 	const newUserObject = {};
@@ -81,8 +81,9 @@ export const addUserToPoints = (userId) => {
 };
 
 export const testDates = (userId, interaction) => {
+	const { guildId } = interaction;
 	const currentDate = Date.now();
-	const { points } = db.data;
+	const { points } = db.data[guildId];
 	let { lastPointsGivenBy } = points[userId];
 	const newLastPointsGivenBy = lastPointsGivenBy.filter(({ date }) => {
 		const pointDate = new Date(date);
@@ -97,7 +98,8 @@ export const testDates = (userId, interaction) => {
 };
 
 export const giveUserAPoint = (userId, interaction) => {
-	const { points } = db.data;
+	const { guildId } = interaction;
+	const { points } = db.data[guildId];
 	const newPoint = new PointsObject(interaction.author.id, Date.now(), interaction.channelId);
 	const newPointGivenBy = new PointGivenBy(interaction.author.id, Date.now());
 	points[userId].pointsReceived.push(newPoint);
@@ -106,22 +108,21 @@ export const giveUserAPoint = (userId, interaction) => {
 };
 
 
-export const countGivenPoint = (userId, messageChannel) => {
-	const { points } = db.data;
+export const countGivenPoint = (userId, messageChannel, guildId) => {
+	const { points } = db.data[guildId];
 	const pointsReceived = points[userId].pointsReceived.filter(({ channel }) => channel === messageChannel);
 	return pointsReceived.length;
 };
 
-export const channelPoints = (channelName, nameAmount = 1) => {
-	const { points } = db.data;
+export const channelPoints = (channelName, nameAmount = 1, guildId) => {
+	const { points } = db.data[guildId];
 	const allUsers = Object.keys(points);
 	const listOfPoints = allUsers.map(userID => {
 		// eslint-disable-next-line no-shadow
-		const points = countGivenPoint(userID, channelName);
+		const points = countGivenPoint(userID, channelName, guildId);
 		return { userID, points };
 	});
 	const sortedList = listOfPoints.sort((a, b) => b.points - a.points);
 	return sortedList.slice(0, nameAmount);
 };
-
 

--- a/db.js
+++ b/db.js
@@ -5,23 +5,23 @@ import fs from "fs";
 class PointsUser {
 	constructor() {
 		this.pointsReceived = [],
-		this.pointsGiven = [],
-		this.lastPointsGivenBy = [];
+			this.pointsGiven = [],
+			this.lastPointsGivenBy = [];
 	}
 }
 
 class PointsObject {
 	constructor(giver, date, channel) {
 		this.givenBy = giver,
-		this.date = date,
-		this.channel = channel;
+			this.date = date,
+			this.channel = channel;
 	}
 }
 
 class PointGivenBy {
 	constructor(userId, date) {
 		this.userId = userId,
-		this.date = date;
+			this.date = date;
 	}
 }
 
@@ -30,9 +30,13 @@ const createDbProps = (db) => {
 	const serverProps = ["867244851098288149", "939629912623575090"];
 	const featureProps = ["points", "example"];
 	serverProps.forEach((prop) => {
-		db.data[prop] = {};
+		if (!db.data[prop]) {
+			db.data[prop] = {};
+		}
 		featureProps.forEach((fprop) => {
-			db.data[prop][fprop] = {};
+			if (!db.data[prop][fprop]) {
+				db.data[prop][fprop] = {};
+			}
 		});
 	});
 	console.log("added necessary server and feature props to db.json");
@@ -88,7 +92,7 @@ export const testDates = (userId, interaction) => {
 	const newLastPointsGivenBy = lastPointsGivenBy.filter(({ date }) => {
 		const pointDate = new Date(date);
 		const dateComparison = currentDate - pointDate;
-		return dateComparison <	 (1000 * 60);
+		return dateComparison < (1000 * 60);
 	});
 	// eslint-disable-next-line no-shadow
 	const isValidPoint = newLastPointsGivenBy.every(({ userId }) => userId !== interaction.author.id);

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -19,7 +19,7 @@ export default {
 		const welcomeMessage = `Hey ${newMember} , welcome to Coding Buddies, we're lucky to have you here. When you have a second, can you please tell us a little about yourself: 1) Where you're from 2) Where you are in your coding journey 3) What goals do you have for coding 4) How you found the server. Reach out to @admin if you have any questions or feedback requests for the server. We're all here to learn and grow together. Happy Coding!`;
 		welcomeChannel.send(welcomeMessage);
 		welcomeChannel.send(randomGif);
-		addUserToPoints(member.user.id);
+		addUserToPoints(member.user.id, member.guildId);
 
 		// const user = event.user.id
 

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -13,7 +13,7 @@ export default {
 
 		// try to add the user to the points DB, if they are already there
 		// db function will reject this
-		addUserToPoints(interaction.author.id);
+		addUserToPoints(interaction.author.id, interaction.guildId);
 
 		// Prefix and message content
 		const { prefix, suffix } = config;
@@ -47,6 +47,9 @@ export default {
 					break;
 				case "!help":
 					helpCommand(interaction, client);
+					break;
+				case "!test":
+					console.log(interaction);
 					break;
 				default:
 					interaction.channel.send(`I didnt recognize the request "${command}"`);

--- a/src/message_replies/givePoint.js
+++ b/src/message_replies/givePoint.js
@@ -10,7 +10,7 @@ import {
 async function givePoint(command, interaction) {
 	const mentionId = getUserIdFromMention(command);
 
-	if (!mentionId) return  interaction.reply(`Sorry <@!${interaction.author.id}>, can't find ${command}.\n(╯°□°）╯︵ ┻━┻`);
+	if (!mentionId) return interaction.reply(`Sorry <@!${interaction.author.id}>, can't find ${command}.\n(╯°□°）╯︵ ┻━┻`);
 
 	const { validUser } = await isUserValid(interaction, mentionId);
 
@@ -29,7 +29,7 @@ async function givePoint(command, interaction) {
 	else {
 		// try to add the user to the DB, if they are already there
 		// db function will reject this
-		addUserToPoints(mentionId);
+		addUserToPoints(mentionId, interaction.guildId);
 		const canAddPoint = testDates(mentionId, interaction);
 		if (!canAddPoint) {
 			interaction.channel.send(
@@ -38,7 +38,7 @@ async function givePoint(command, interaction) {
 		}
 		if (canAddPoint) {
 			giveUserAPoint(mentionId, interaction);
-			const userPoints = countGivenPoint(mentionId, interaction.channelId);
+			const userPoints = countGivenPoint(mentionId, interaction.channelId, interaction.guildId);
 			const emojis = [ "🔥", "💯", "💃🏾", "💪🏾"];
 			const randomNumber = Math.floor(Math.random() * 3);
 			interaction.channel.send(

--- a/src/message_replies/reportChannelPoints.js
+++ b/src/message_replies/reportChannelPoints.js
@@ -3,7 +3,7 @@ import { isUserValid } from "../utils/isUserValid.js";
 
 const reportChannelPoints = async (interaction) => {
 	const { channelId } = interaction;
-	const topPointEarners = channelPoints(channelId, 5);
+	const topPointEarners = channelPoints(channelId, 5, interaction.guildId);
 
 	let currentChannelPoints = 0;
 	topPointEarners.forEach((obj) => currentChannelPoints += obj.points);


### PR DESCRIPTION
this change allows for support of both the development and the live server.

Had to update the checkDB function to add a a prop for each of the servers (dev and prod) and then pass in the guildId to each of the db functions to pull the points object from the correct server, based on which server the message was in. they all look at this now `const { points } = db.data[guildId]` 

This should solve our issue.