### PR TITLE
Cub/bugfix - refactors commands with prefix.

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -49,7 +49,8 @@ export default {
 					helpCommand(interaction, client);
 					break;
 				default:
-					interaction.channel.send(`I didnt recognize the request "${command}"`);
+					//interaction.channel.send(`I didnt recognize the request "${command}"`);
+					return
 				}
 			}
 			if (command.at(1) === "@" && command.includes(suffix)) {


### PR DESCRIPTION
based on the discussion on the group, I made 2 changes:
- prefix commands will now return only if it is at the beginning of the message.
- prefix commands will only response 1 command at time.

also, this should be at v1.1 not v2.0